### PR TITLE
@ - expressions in class method arguments

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -465,20 +465,19 @@ function mapInArrayExpression(node, meta) {
   );
 }
 
-function extractArgumentMemberAssignment(nodes) {
+function extractAssignStatementsByArguments(nodes) {
   return nodes
-  .filter(node =>
-          node.type === 'AssignmentExpression' &&
-          node.left.type === 'MemberExpression')
-  .map(node =>
-    b.expressionStatement(
-      b.assignmentExpression(
-        node.operator,
-        node.left,
-        node.left.property
+    .map(node => node.type === 'AssignmentExpression' ? node.left : node)
+    .filter(node => node.type === 'MemberExpression' && node.object.type === 'ThisExpression')
+    .map(node =>
+      b.expressionStatement(
+        b.assignmentExpression(
+          '=',
+          node,
+          node.property
+        )
       )
-    )
-  );
+    );
 }
 
 function normalizeArguments(nodes) {
@@ -490,6 +489,10 @@ function normalizeArguments(nodes) {
         node.left.property,
         node.right
       );
+    }
+    if (node.type === 'MemberExpression' &&
+       node.object.type === 'ThisExpression') {
+      return {type: 'Identifier', name: node.property.name};
     }
     return node;
   });
@@ -737,7 +740,7 @@ function mapFunction(node, meta) {
   // For our compilation we translate it like
   // fn = function() { this.a = arguments[0]; } as there is no 1 to 1
   // solution here
-  setupStatements = setupStatements.concat(extractArgumentMemberAssignment(args, meta));
+  setupStatements = setupStatements.concat(extractAssignStatementsByArguments(args, meta));
 
   const block = addReturnStatementToBlock(mapBlockStatement(node.body, meta), meta);
 

--- a/test/test.js
+++ b/test/test.js
@@ -448,6 +448,26 @@ describe('FunctionExpression', () => {
 };`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('fn = (@a, b) => console.log a, b', () => {
+    const example = `fn = (@a, b) => console.log a, b`;
+    const expected =
+`var fn = (a, b) => {
+  this.a = a;
+  return console.log(a, b);
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('fn = (@a, b) -> console.log a, b', () => {
+    const example = `fn = (@a, b) -> console.log a, b`;
+    const expected =
+`var fn = function(a, b) {
+  this.a = a;
+  return console.log(a, b);
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('ClassExpression', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -545,6 +545,20 @@ describe('ClassExpression', () => {
     expect(compile(example)).toEqual(expected);
   });
 
+  it('assigns @ arguments to this', ()=> {
+    const example =
+`class A
+  constructor: (@b) ->`;
+
+    const expected =
+`class A {
+  constructor(b) {
+    this.b = b;
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   describe('super', () => {
     it(`maps super 1 to 1 if in constructor`, () => {
       const example =


### PR DESCRIPTION
`@` arguments doesn't work.

coffeescript
```coffeescript
class A
  constructor: (@b) ->
```

before es6 output
```javascript
class A {
  constructor(this.b) {}
}
```

after es6 output
```javascript
class A {
  constructor(b) {
    this.b = b;
  }
}
```