### PR TITLE
Add CLI

### DIFF
--- a/bin/decafjs
+++ b/bin/decafjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+var program = require('commander');
+var dir = require('node-dir');
+var join = require('path').join;
+var dirname = require('path').dirname;
+var basename = require('path').basename;
+var extname = require('path').extname;
+var fs = require('fs');
+var decaf = require('../dist/index');
+
+program
+  .version(require('../package.json').version)
+  .usage('<path>... [options]')
+  .description('<path> is coffeescript files or directory')
+  .option('-p, --print', 'Print output')
+  .parse(process.argv);
+
+if (program.args.length === 0) {
+  program.help();
+  process.exit(0);
+}
+run(program.args, program);
+
+function run(paths, config) {
+  paths.forEach(function (path) {
+    if (!fs.existsSync(path)) {
+      console.log('Skipping path "%s" which does not exist.', path);
+      return;
+    }
+
+    var stats = fs.statSync(path);
+    if (stats.isDirectory()) {
+      dir.files(path, function (err, files) {
+        files.filter(function (file) {
+          return fs.statSync(file).isFile() && /.*\.coffee$/.test(file);
+        }).forEach(function (file) {
+          runByFile(file, config);
+        });
+      });
+    } else {
+      runByFile(path, config);
+    }
+  });
+}
+
+function runByFile(file, config) {
+  var coffee = fs.readFileSync(file, { encoding: 'utf8'});
+  try {
+    var js = decaf.compile(coffee);
+
+    var outputPath = join(dirname(file), basename(file, extname(file))) + '.js';
+    var output = fs.createWriteStream(outputPath, { encoding: 'utf8' });
+    if (config.print) {
+      output = process.stdout;
+    }
+    output.write(js);
+
+    if (output !== process.stdout) {
+      console.log('Generate es6 file "%s" from "%s".', output.path, file);
+    }
+  } catch (e) {
+    console.log('Skipping path "%s" which parsed error.', file);
+    console.log(e.stack);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "url": "git@github.com:juliankrispel/decaf.git"
   },
   "main": "dist/index.js",
+  "bin": {
+    "decafjs": "bin/decafjs"
+  },
   "scripts": {
     "test:mocha": "mocha --compilers js:babel-core/register -R ../../../reporter",
     "test:lint": "eslint src",
@@ -21,8 +24,10 @@
   "dependencies": {
     "ast-types": "0.8.13",
     "coffee-script": "1.10.0",
+    "commander": "^2.9.0",
     "jscodeshift": "0.3.12",
     "lodash": "3.10.1",
+    "node-dir": "^0.1.11",
     "recast": "benjamn/recast#b0f031b1a36199308a1eb77cc9709d554f14e671"
   },
   "devDependencies": {


### PR DESCRIPTION
I want a CLI for decaf. 
My use-case is convert all `.coffee` files in directory recursively to `.js` file. 

like this:

```sh
$ decafjs

  Usage: decafjs <path>... [options]

  <path> is coffeescript files or directory

  Options:

    -h, --help     output usage information
    -V, --version  output the version number
    -p, --print    Print output

# Files
$ decafjs coffee/a.coffee
Generate es6 file "coffee/a.js" from "coffee/a.coffee".

$ decafjs coffee/a.coffee coffee/b.coffee
Generate es6 file "coffee/a.js" from "coffee/a.coffee".
Generate es6 file "coffee/b.js" from "coffee/b.coffee".

# Directories
$ tree coffee
coffee/
├── a.coffee
├── b.coffee
└── sub_dir
    ├── c.coffee
    └── illegal.coffee

$ decafjs coffee/
Generate es6 file "coffee/a.js" from "coffee/a.coffee".
Generate es6 file "coffee/b.js" from "coffee/b.coffee".
Generate es6 file "coffee/sub_dir/c.js" from "coffee/sub_dir/c.coffee".
Skipping path "coffee/sub_dir/illegal.coffee" which parsed error.
[show stacktrace]

$ tree coffee
coffee
├── a.coffee
├── a.js
├── b.coffee
├── b.js
└── sub_dir
    ├── c.coffee
    ├── c.js
    └── illegal.coffee

# Options
$ decafjs coffee/a.coffee -p
class A {
  constructor() {
    this.hello.bind(this);
  }

  hello() {
    return console.log("Hello World");
  }
}
```
How about this PR CLI feature? Could you give me feedback?