### PR TITLE
[WIP] extends operator

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -759,6 +759,17 @@ describe('ClassExpression', () => {
   });
 });
 
+describe('extends keyword', () => {
+  it.only('extends plain objects', () => {
+    const example =
+`a = a: 1
+b = b: 2
+c = a extends b`;
+    const expected = ``;
+    expect(compile(example)).toEqual(expected);
+  });
+});
+
 describe('Destructuring', () => {
   it('maps simple object destructuring assignments', () => {
     const example = `{a, b} = abam`;


### PR DESCRIPTION
I'm not quite sure yet how to deal with coffeescript attaching functions to the top of a module.

I originally thought I could avoid this but it looks less and less so. I have a similar problem with the modulo operator in issue #6 