### PR TITLE
fixed return statement, if expression is not exists

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -481,7 +481,7 @@ function mapTryCatchBlock(node, meta) {
 }
 
 function mapReturnStatement(node, meta) {
-  return b.returnStatement(mapExpression(node.expression, meta));
+  return b.returnStatement(node.expression ? mapExpression(node.expression, meta) : null);
 }
 
 function mapStatement(node, meta) {

--- a/test/test.js
+++ b/test/test.js
@@ -302,6 +302,15 @@ describe('return statements', () => {
     expect(compile(example)).toEqual(expected);
   });
 
+  it('a = ()-> return', () => {
+    const example = 'a = ()-> return';
+    const expected =
+`var a = function() {
+  return;
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   it('a = ()-> return "boom" if b is 123', () => {
     const example = 'a = ()-> return "boom" if b is 123';
     const expected =


### PR DESCRIPTION
return statement fixed by https://github.com/juliankrispel/decaf/pull/26 .
but error occured in following case.

coffee
```coffee
a = ()-> return
```
error
```
TypeError: Cannot read property 'constructor' of undefined
  at mapExpression (node_modules/decafjs/dist/index.js:920:18)
  at mapReturnStatement (node_modules/decafjs/dist/index.js:436:45)
  at mapStatement (node_modules/decafjs/dist/index.js:447:12)
  at node_modules/decafjs/dist/index.js:469:12
  at Array.map (native)
  at mapBlockStatements (node_modules/decafjs/dist/index.js:468:27)
```
Fixed this error.