### PR TITLE
Integrated coffee-script scope object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:mocha": "mocha --require mocha-compiler",
     "test:lint": "eslint src",
     "test": "npm run test:mocha && npm run test:lint",
+    "testDebug": "mocha debug --require mocha-compiler",
     "build": "mkdir -p dist && babel src/parser.js --out-file dist/index.js",
     "watchTest": "mocha -w --require mocha-compiler",
     "watchTestDebug": "mocha -w debug --require mocha-compiler",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1532,9 +1532,7 @@ export function transpile(ast, meta) {
 
   utils.forEach(util => {
     const expr = recast.parse(
-      utilities[util] +
-      ' = ' +
-      UTILITIES[util](meta)
+      `${utilities[util]} = ${UTILITIES[util](meta)}`
     ).program.body[0];
 
     delete expr.loc;


### PR DESCRIPTION
- [x] integrated coffeescript scope object.
- [x] usage of coffeescripts variable register to prevent naming collisions.
- [x] cs utility functions.

fixes #82, #65, #7 and #6. Also makes it a ton easier to do cs compiler fallbacks in general.