### PR TITLE
Update gh-pages branch automatically.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build": "mkdir -p dist && babel src/parser.js --out-file dist/index.js",
     "watchTest": "mocha -w --require mocha-compiler",
     "watchTestDebug": "mocha -w debug --require mocha-compiler",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postpublish": "./scripts/update-gh-pages.sh"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-plugin-object-assign": "1.2.1",
     "babel-plugin-transform-object-assign": "6.1.18",
     "babel-preset-es2015": "6.1.18",
+    "browserify": "^13.0.0",
     "eslint": "1.10.3",
     "eslint-config-airbnb": "4.0.0",
     "eslint-plugin-babel": "3.0.0",

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+PATH="$(npm bin):$PATH"
+hasChanges() {
+  git status >/dev/null # update the cache
+  if git diff-index --quiet HEAD --; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+# Get the current version.
+VERSION=$(node -e 'console.log(require("./package.json").version)')
+
+# Build the browser version.
+browserify -e dist/index.js -s decaf -o dist/decaf.js
+
+# Switch to gh-pages branch.
+git fetch origin
+git checkout gh-pages
+git reset --hard origin/gh-pages || echo "No updates from server."
+
+# Update the script in the gh-pages branch.
+mv dist/decaf.js scripts/
+perl -p -i -e "s/v\d+\.\d+\.\d+/v$VERSION/" index.html
+if hasChanges; then
+  git commit -av -m "Update decaf.js."
+  git push origin gh-pages
+fi
+
+# Go back to the master branch.
+git checkout master


### PR DESCRIPTION
ref https://github.com/juliankrispel/decaf/pull/105

I added `./scripts/update-gh-pages.sh` for update gh-pages branch, that will invoke after `npm publish` command. update files in gh-pages branch is as follows.
* scripts/decaf.js
* index.html

There is sample result and created commit https://github.com/tsuchikazu/decaf/commit/5cf80cded03649a70aaa17c2af3048895615e7c4.
```
$ sh -x ./scripts/update-gh-pages.sh
+ set -e
++ npm bin
+ PATH=/Users/usr0600249/src/github.com/tsuchikazu/decaf/node_modules/.bin::/sbin:usr/local/bin
++ node -e 'console.log(require("./package.json").version)'
+ VERSION=0.3.1
+ browserify -e dist/index.js -s decaf -o dist/decaf.js
+ git fetch origin
+ git checkout gh-pages
Switched to branch 'gh-pages'
Your branch is behind 'origin/gh-pages' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)
+ git reset --hard origin/gh-pages
HEAD is now at 9e81724 Update decaf.js.
+ mv dist/decaf.js scripts/
+ perl -p -i -e 's/v\d+\.\d+\.\d+/v0.3.1/' index.html
+ hasChanges
+ git status
+ git diff-index --quiet HEAD --
+ return 1
+ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
```