### PR TITLE
Add support for more kinds of slices.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -102,13 +102,20 @@ function mapRange(node, meta) {
 }
 
 function mapSlice(node, meta) {
-  return b.callExpression(
-    b.identifier('slice'),
-    [
-      mapExpression(node.range.from, meta),
-      mapExpression(node.range.to, meta),
-    ]
-  );
+  const {range} = node;
+  const args = [range.from ? mapExpression(range.from, meta) : b.literal(0)];
+  if (range.to) {
+    let to = mapExpression(range.to, meta);
+    if (!range.exclusive) {
+      if (to.type === 'Literal' && typeof to.value === 'number' && Math.round(to.value) === to.value) {
+        to.value += 1;
+      } else {
+        to = b.binaryExpression('+', to, b.literal(1));
+      }
+    }
+    args.push(to);
+  }
+  return b.callExpression(b.identifier('slice'), args);
 }
 
 function mapValue(node, meta) {

--- a/test/test.js
+++ b/test/test.js
@@ -1833,6 +1833,42 @@ describe('slices', () => {
     const expected = `bam.slice(a["foobar"].bom, 100);`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('bam[1..10]', () => {
+    const example = `bam[1..10]`;
+    const expected = `bam.slice(1, 11);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[1..10.5]', () => {
+    const example = `bam[1..10.5]`;
+    const expected = `bam.slice(1, 10.5 + 1);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[a()..b()]', () => {
+    const example = `bam[a()..b()]`;
+    const expected = `bam.slice(a(), b() + 1);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[1..]', () => {
+    const example = `bam[1..]`;
+    const expected = `bam.slice(1);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[..1]', () => {
+    const example = `bam[..1]`;
+    const expected = `bam.slice(0, 2);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('bam[..]', () => {
+    const example = `bam[..]`;
+    const expected = `bam.slice(0);`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('conditional expressions', () => {


### PR DESCRIPTION
- inclusive slices with special case for integers
- slices without a `from`
- slices without a `to`
- slices with neither `from` nor `to`

This came from trying to run `decaf` on
https://github.com/jashkenas/coffeescript/blob/88192c197a86759e25e1a0d8a31909b72a96cbc8/src/cake.coffee#L52.