### PR TITLE
Unnamed class expressions

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -396,7 +396,10 @@ function mapClassExpression(node, meta) {
 function mapClassDeclaration(node, meta) {
   let parent = null;
 
-  node.ensureConstructor(node.variable.base.value);
+  if (node.variable) {
+    node.ensureConstructor(node.variable.base.value);
+  }
+
   const code = new Code([], Block.wrap([node.body]));
   meta = Object.assign({}, meta, {classScope: code.makeScope(meta.scope)});
 
@@ -410,6 +413,14 @@ function mapClassDeclaration(node, meta) {
 
   if (node.parent !== undefined && node.parent !== null) {
     parent = mapExpression(node.parent, meta);
+  }
+
+  if (!node.variable) {
+    return b.classDeclaration(
+      b.identifier(meta.scope.freeVariable('unnamedClass')),
+      mapClassBody(node.body, meta),
+      parent
+    );
   }
 
   return b.classDeclaration(

--- a/test/test.js
+++ b/test/test.js
@@ -836,6 +836,24 @@ describe('ClassExpression', () => {
     expect(compile(example)).toEqual(expected);
   });
 
+  it('can compile unnamed class expressions and prevent naming collisions', () => {
+    const example =
+`class extends Parent
+  boom: ->
+class extends Parent
+  boom: ->`;
+
+    const expected =
+`class unnamedClass extends Parent {
+  boom() {}
+}
+
+class unnamedClass1 extends Parent {
+  boom() {}
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
   it('renders a simple class expression with a method', () => {
     const example =
 `class A


### PR DESCRIPTION
What this does is it uses coffeescripts freeVariable method to get a class name for the unnamed class (es6 needs a class name). I've used the name unnamedClass for this. cc @mizchi

fixes #97