### PR TITLE
Empty object in parameter, don't throw error for legal super call

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -189,6 +189,13 @@ function mapOp(node, meta) {
 
 function mapArguments(args, meta) {
   return args.map(arg => {
+    const argName = get(arg.name, 'constructor.name');
+    if ((argName === 'Obj' && arg.name.objects.length === 0) ||
+        (argName === 'Arr' && arg.name.objects.length === 0)
+       ) {
+      return b.identifier(meta.scope.freeVariable('arg'));
+    }
+
     if (arg.constructor.name === 'Expansion') {
       return b.restElement(b.identifier(meta.scope.freeVariable('args')));
     }
@@ -799,6 +806,7 @@ function detectIllegalSuper(node, meta) {
 
   const hasSuperCallAfterThisAssignments =
     isExtendedClass &&
+    isConstructor &&
     firstThisAssignmentIndex > -1 &&
     superIndex > firstThisAssignmentIndex;
 

--- a/test/test.js
+++ b/test/test.js
@@ -636,6 +636,15 @@ bam = "bye";`;
     expect(compile.bind(this, example)).toThrow();
   });
 
+  it('doesn\'t throw an error when super is called within a method other than constructor', () => {
+    const example =
+`class A extends B
+  b: () ->
+    @a = 'boom'
+    super`;
+    expect(compile.bind(this, example)).toNotThrow();
+  });
+
   it('declares variables in class methods', () => {
     const example =
 `class A extends B
@@ -821,6 +830,12 @@ describe('FunctionExpression', () => {
   this.a = a;
   return console.log(a, b);
 };`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('turns empty object or array parameter into normal parameter, prevents naming collisions', () => {
+    const example = 'fn = ({}, bo, [], ba) ->';
+    const expected = `var fn = function(arg, bo, arg1, ba) {};`;
     expect(compile(example)).toEqual(expected);
   });
 });


### PR DESCRIPTION
fixes #131