### PR TITLE
Use eval to evaluate string literals

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -18,8 +18,6 @@ const IS_NUMBER = /^[+-]?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)$/i;
 const IS_STRING = /^['"]/;
 const IS_REGEX = /^\//;
 
-const STRING_INSIDE_QUOTES = /^['"](.*)['"]$/;
-
 function mapBoolean(node) {
   if (node.base.val === 'true') {
     return b.literal(true);
@@ -66,7 +64,7 @@ function mapLiteral(node) {
   if (value === 'NaN') {
     return b.literal(NaN);
   } else if (IS_STRING.test(value)) {
-    return b.literal(value.match(STRING_INSIDE_QUOTES)[1]);
+    return b.literal(eval(value)); // eslint-disable-line no-eval
   } else if (IS_NUMBER.test(value)) {
     return b.literal(Number(value));
   } else if (IS_REGEX.test(value)) {

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,10 @@ function compile(source) {
 describe('Values', () => {
   it('strings', () => {
     expect(compile('"yoyoyo"')).toEqual('"yoyoyo";');
+    expect(compile(`"#{_.escape(text).replace(/\\n/g, '<br>')}<br>"`)).toEqual(`(_.escape(text).replace(/\\n/g, "<br>")) + "<br>";`);
+    expect(compile(`'\\''`)).toEqual(`"'";`);
+    expect(compile(`"\\""`)).toEqual(`"\\"";`);
+    expect(compile(`"\\\\\\\\"`)).toEqual(`"\\\\";`);
   });
 
   it('numbers', () => {
@@ -63,6 +67,18 @@ describe('multiline strings', () => {
 "
 """`;
     const expected = String.raw`"\"";`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('should escape more complex strings properly', () => {
+    const example =
+`"""
+<div id="outer" style="height: #{CONTAINER_HEIGHT}px; overflow: scroll">
+  <div id="inner" style="height: #{CONTENT_HEIGHT}px"></div>
+</div>
+"""`;
+
+    const expected = `"<div id=\\"outer\\" style=\\"height: " + (CONTAINER_HEIGHT) + "px; overflow: scroll\\">\\n  <div id=\\"inner\\" style=\\"height: " + (CONTENT_HEIGHT) + "px\\"></div>\\n</div>";`; // eslint-disable-line max-len
     expect(compile(example)).toEqual(expected);
   });
 });


### PR DESCRIPTION
There are a lot of string literal issues that seem to stem from incorrect string escaping. This PR uses `eval` to make sure we get the proper value.

@lemonmade @juliankrispel 