### PR TITLE
Prefer empty `finally` block for catchless `try`

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -537,33 +537,28 @@ function mapConditionalStatement(node, meta) {
 }
 
 function mapTryCatchBlock(node, meta) {
-  let recovery;
-  let errorVar;
   let finalize = null;
+  let catchBlock = null;
+  if (node.recovery) {
+    const recovery = mapBlockStatement(node.recovery, meta);
+    const errorVar = mapLiteral({base: node.errorVariable}, meta);
+
+    catchBlock = b.catchClause(
+      errorVar,
+      null,
+      recovery
+    );
+  }
 
   if (node.ensure) {
     finalize = mapBlockStatement(node.ensure, meta);
-  }
-
-  if (node.recovery) {
-    recovery = mapBlockStatement(node.recovery, meta);
-  } else {
-    recovery = b.blockStatement([]);
-  }
-
-  if (node.errorVariable) {
-    errorVar = mapLiteral({base: node.errorVariable}, meta);
-  } else {
-    errorVar = b.identifier('undefined');
+  } else if (!catchBlock) {
+    finalize = b.blockStatement([]);
   }
 
   return b.tryStatement(
     mapBlockStatement(node.attempt, meta),
-    b.catchClause(
-      errorVar,
-      null,
-      recovery
-    ),
+    catchBlock,
     finalize
   );
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1492,7 +1492,7 @@ catch err
     const expected =
 `try {
   var [[], name, context] = expression.match(/s*['"](.*?)['"](?:,s*(.*))?s*/);
-} catch (undefined) {}`;
+} finally {}`;
     expect(compile(example)).toEqual(expected);
   });
 
@@ -1539,7 +1539,7 @@ finally
 `var x = (() => {
   try {
     return y();
-  } catch (undefined) {}
+  } finally {}
 })();`;
     expect(compile(example)).toEqual(expected);
   });
@@ -1568,7 +1568,7 @@ var x = (() => {
     })();
 
     return a + " boo";
-  } catch (undefined) {}
+  } finally {}
 })();`;
     expect(compile(example)).toEqual(expected);
   });


### PR DESCRIPTION
Why?
- `catch (undefined)` triggers a few common lint errors (no-catch-shadow, no-shadow-restricted-names, no-undefined)
- try/finally blocks no longer get an unnecessary empty catch