### PR TITLE
Fix complex `for when` translation

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -158,6 +158,14 @@ function mapOp(node, meta) {
       !node.flip);
   }
 
+  if (node.properties) {
+    return mapExpression(node, meta);
+  }
+
+  if (node.args) {
+    return mapCall(node, meta);
+  }
+
   if (!node.second) {
     return b.unaryExpression(
       operator,
@@ -1045,6 +1053,20 @@ function mapSwitchStatement(node, meta) {
   );
 }
 
+function mapForGuard(guardNode, blockStatement, meta) {
+  const isExistential = guardNode.constructor.name === 'Existence';
+  const guardClause = isExistential ?
+    mapExistentialExpression(guardNode, meta) :
+    mapOp(guardNode.expression || guardNode, meta);
+
+  return b.blockStatement([
+    b.ifStatement(
+      guardClause,
+      blockStatement
+    ),
+  ]);
+}
+
 function mapForStatement(node, meta) {
   let blockStatement = mapBlockStatement(node.body, meta);
 
@@ -1052,12 +1074,7 @@ function mapForStatement(node, meta) {
   // is a conditional expression attached to the for
   // loop
   if (node.guard) {
-    blockStatement = b.blockStatement([
-      b.ifStatement(
-      mapOp(node.guard),
-      blockStatement
-      ),
-    ]);
+    blockStatement = mapForGuard(node.guard, blockStatement, meta);
   }
 
   if (node.object === false) {

--- a/test/test.js
+++ b/test/test.js
@@ -1879,6 +1879,123 @@ describe('for loops with conditional', () => {
 }`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('handles truthy existential property', () => {
+    const example = `loopAction(value) for value in values when value?`;
+
+    const expected =
+`for (var value of values) {
+  if (typeof value !== "undefined" && value !== null) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles truthy member property', () => {
+    const example =
+`for value in values when foo.bar
+  loopAction(value);
+`;
+
+    const expected =
+`for (var value of values) {
+  if (foo.bar) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles existential truthy member property', () => {
+    const example =
+`for value in values when foo.bar?.qux
+  loopAction(value)
+`;
+
+    const expected =
+`var ref;
+
+for (var value of values) {
+  if ((ref = foo.bar) != null ? ref.qux : void 0) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles conditional call', () => {
+    const example = `loopAction(value) for value in values when foo?()`;
+
+    const expected =
+`for (var value of values) {
+  if (typeof foo === "function" ? foo() : void 0) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles member conditional call', () => {
+    const example = `loopAction(value) for value in values when foo?.bar?.qux?()`;
+    /* eslint-disable max-len */
+    const expected =
+`var ref;
+
+for (var value of values) {
+  if (typeof foo !== "undefined" && foo !== null ? ((ref = foo.bar) != null ? (typeof ref.qux === "function" ? ref.qux() : void 0) : void 0) : void 0) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles existential logical expression', () => {
+    const example =
+`for value in values when regex?.test(foo.bar) || regex.test(bar.foo)
+  loopAction(value);
+`;
+
+    const expected =
+`for (var value of values) {
+  if (((typeof regex !== "undefined" && regex !== null ? regex.test(foo.bar) : void 0)) || regex.test(bar.foo)) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('isnt with conditional member access', () => {
+    const example =
+`for value in values when foo.bar?[value] isnt bar[value]
+  return loopAction(value);
+`;
+
+    const expected =
+`var ref;
+
+for (var value of values) {
+  if ((((ref = foo.bar) != null ? ref[value] : void 0)) !== bar[value]) {
+    return loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('instanceof', () => {
+    const example =
+`for value in values when value instanceof Foo
+  loopAction(value)
+`;
+
+    const expected =
+`for (var value of values) {
+  if (value instanceof Foo) {
+    loopAction(value);
+  }
+}`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('ranges', () => {


### PR DESCRIPTION
More `for...when` loops translate without error.