### PR TITLE
`foo?.bar = 'car'` should convert to valid JavaScript

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1479,10 +1479,11 @@ function mapExistentialAssignmentExpression(node, meta) {
   const condition = mapExistentialExpression(unsoaked.condition, meta);
   const assignTarget = mapExpression(unsoaked.body, meta);
   const assignValue = mapExpression(node.value, meta);
+  const operator = node.context || '=';
 
   return b.conditionalExpression(
     condition,
-    b.assignmentExpression('=', assignTarget, assignValue),
+    b.assignmentExpression(operator, assignTarget, assignValue),
     b.unaryExpression('void', b.literal(0))
   );
 }

--- a/test/test.js
+++ b/test/test.js
@@ -847,6 +847,14 @@ describe('existential assignment', () => {
 };`;
     expect(compile(example)).toEqual(expected);
   });
+
+  it('handles increment-assign', () => {
+    const example = `foo.bar?.car += qux`
+    const expected =
+`var ref;
+((ref = foo.bar) != null ? ref.car += qux : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
 });
 
 describe('FunctionExpression', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -813,6 +813,42 @@ class A extends B {
   });
 });
 
+describe('existential assignment', () => {
+  it('handles soaked variable', () => {
+    const example = `foo?.bar = "buzz" || ""`;
+    const expected = `(foo != null ? foo.bar = "buzz" || "" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles soaked variable property', () => {
+    const example = `foo.bar?.car = "qux"`;
+    const expected =
+`var ref;
+((ref = foo.bar) != null ? ref.car = "qux" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles soaked method call', () => {
+    const example = `foo.bar()?.car = "qux"`;
+    const expected =
+`var ref;
+((ref = foo.bar()) != null ? ref.car = "qux" : void 0);`;
+    expect(compile(example)).toEqual(expected);
+  });
+
+  it('handles return-assignments', () => {
+    const example =
+`bam = ->
+  foo?.bar = "buzz"`;
+
+    const expected =
+`var bam = function() {
+  return (foo != null ? foo.bar = "buzz" : void 0);
+};`;
+    expect(compile(example)).toEqual(expected);
+  });
+});
+
 describe('FunctionExpression', () => {
   it('fn = (a,b) -> console.log a, b', () => {
     const example = `fn = (a,b) -> console.log a, b`;


### PR DESCRIPTION
Previously, the above code would translate to:
```
var foo != null ? foo.bar : void 0 = "car";
```

/cc @lemonmade 